### PR TITLE
Cordova 4 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@ cordova-parse-plugin
 ====================
 
 Cordova Plugin for Parse
+											   
+Requires Cordova v4.0.0 or above.

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
 	<license>Apache License, Version 2.0</license>
 	<keywords>Parse</keywords>
 	<engines>
-		<engine name="cordova" version=">=3.5.0"/>
+		<engine name="cordova" version=">=4.0.0"/>
 	</engines>
 	<js-module src="www/ParsePlugin.js" name="ParsePlugin">
 		<clobbers target="ParsePlugin"/>

--- a/plugin.xml
+++ b/plugin.xml
@@ -23,6 +23,7 @@
 			<receiver android:name="se.frostyelk.cordova.parse.plugin.ParseWakeUpReceiver">
 				<intent-filter>
 					<action android:name="com.google.android.c2dm.intent.RECEIVE"/>
+					<action android:name="android.intent.action.BOOT_COMPLETED"/>
 					<action android:name="android.intent.action.USER_PRESENT"/>
 					<category android:name="$PACKAGE_NAME"/>
 				</intent-filter>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,122 +1,97 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-
+<?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://cordova.apache.org/ns/plugins/1.0" id="se.frostyelk.cordova.parse.plugin" version="0.1.2">
-    <name>Cordova Parse plugin</name>
-    <description>Cordova plugin for Parse</description>
-    <author>Arne Sikstrom</author>
-    <license>Apache License, Version 2.0</license>
-    <keywords>Parse</keywords>
-
-    <engines>
-        <engine name="cordova" version=">=3.5.0"/>
-    </engines>
-
-    <js-module src="www/ParsePlugin.js" name="ParsePlugin">
-        <clobbers target="ParsePlugin"/>
-    </js-module>
-
-    <dependency id="com.google.playservices" />
-
-    <platform name="android">
-        <config-file target="res/xml/config.xml" parent="/*">
-            <feature name="ParsePlugin">
-                <param name="android-package" value="se.frostyelk.cordova.parse.plugin.ParsePlugin"/>
-            </feature>
-        </config-file>
-
-        <config-file target="AndroidManifest.xml" parent="/manifest/application">
-            <service android:name="com.parse.PushService"/>
-
-            <receiver android:name="se.frostyelk.cordova.parse.plugin.ParseWakeUpReceiver">
-                <intent-filter>
-                    <action android:name="com.google.android.c2dm.intent.RECEIVE"/>
-                    <action android:name="android.intent.action.USER_PRESENT"/>
-                    <category android:name="$PACKAGE_NAME"/>
-                </intent-filter>
-            </receiver>
-
-            <receiver android:name="com.parse.ParseBroadcastReceiver">
-                <intent-filter>
-                    <action android:name="android.intent.action.BOOT_COMPLETED"/>
-                    <action android:name="android.intent.action.USER_PRESENT"/>
-                </intent-filter>
-            </receiver>
-
-
-            <receiver android:name="com.parse.GcmBroadcastReceiver"
-                      android:permission="com.google.android.c2dm.permission.SEND">
-                <intent-filter>
-                    <action android:name="com.google.android.c2dm.intent.RECEIVE"/>
-                    <action android:name="com.google.android.c2dm.intent.REGISTRATION"/>
-                    <category android:name="$PACKAGE_NAME"/>
-                </intent-filter>
-            </receiver>
-
-            <receiver android:exported="false"
-                      android:name="se.frostyelk.cordova.parse.plugin.ParsePluginBroadcastReciever">
-                <intent-filter>
-                    <action android:name="com.parse.push.intent.RECEIVE"/>
-                    <action android:name="com.parse.push.intent.OPEN"/>
-                    <action android:name="com.parse.push.intent.DELETE"/>
-                </intent-filter>
-            </receiver>
-
-        </config-file>
-
-        <config-file target="AndroidManifest.xml" parent="/manifest">
-            <uses-permission android:name="android.permission.INTERNET"/>
-            <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-            <uses-permission android:name="android.permission.WAKE_LOCK"/>
-            <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
-            <uses-permission android:name="android.permission.VIBRATE"/>
-            <uses-permission android:name="android.permission.GET_ACCOUNTS"/>
-            <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE"/>
-            <permission android:protectionLevel="signature" android:name="$PACKAGE_NAME.permission.C2D_MESSAGE"/>
-            <uses-permission android:name="$PACKAGE_NAME.permission.C2D_MESSAGE"/>
-        </config-file>
-
-        <source-file src="libs/android/parse/Parse-1.8.2.jar" target-dir="libs" framework="true"/>
-        <source-file src="libs/android/parse/bolts-android-1.1.4.jar" target-dir="libs" framework="true"/>
-        <source-file src="libs/android/parse/ParseCrashReporting-1.8.2.jar" target-dir="libs" framework="true"/>
-
-        <source-file src="src/android/ParsePlugin.java" target-dir="src/se/frostyelk/cordova/parse/plugin/"/>
-        <source-file src="src/android/ParsePluginBroadcastReciever.java"
-                     target-dir="src/se/frostyelk/cordova/parse/plugin/"/>
-        <source-file src="src/android/ParseWakeUpReceiver.java" target-dir="src/se/frostyelk/cordova/parse/plugin/"/>
-    </platform>
-
-
-    <platform name="ios">
-        <config-file target="config.xml" parent="/*">
-            <feature name="ParsePlugin">
-                <param name="ios-package" value="ParsePlugin"/>
-                <param name="deployment-target" value="7.0"/>
-            </feature>
-        </config-file>
-
-        <header-file src="src/ios/objc/ParsePlugin.h"/>
-        <source-file src="src/ios/objc/ParsePlugin.m"/>
-
-        <header-file src="src/ios/objc/AppDelegate+ParsePushNotification.h"/>
-        <source-file src="src/ios/objc/AppDelegate+ParsePushNotification.m"/>
-
-        <framework src="libs/ios/Parse.framework" custom="true"/>
-        <framework src="libs/ios/Bolts.framework" custom="true"/>
-
-        <framework src="Accounts.framework"/>
-        <framework src="Social.framework"/>
-        <framework src="AudioToolbox.framework"/>
-        <framework src="CFNetwork.framework"/>
-        <framework src="CoreGraphics.framework"/>
-        <framework src="CoreLocation.framework"/>
-        <framework src="MobileCoreServices.framework"/>
-        <framework src="QuartzCore.framework"/>
-        <framework src="Security.framework"/>
-        <framework src="StoreKit.framework"/>
-        <framework src="SystemConfiguration.framework"/>
-        <framework src="libz.dylib"/>
-        <framework src="libsqlite3.dylib"/>
-
-    </platform>
-
+	<name>Cordova Parse plugin</name>
+	<description>Cordova plugin for Parse</description>
+	<author>Arne Sikstrom</author>
+	<license>Apache License, Version 2.0</license>
+	<keywords>Parse</keywords>
+	<engines>
+		<engine name="cordova" version=">=3.5.0"/>
+	</engines>
+	<js-module src="www/ParsePlugin.js" name="ParsePlugin">
+		<clobbers target="ParsePlugin"/>
+	</js-module>
+	<dependency id="cordova-plugin-googleplayservices"/>
+	<platform name="android">
+		<config-file target="res/xml/config.xml" parent="/*">
+			<feature name="ParsePlugin">
+				<param name="android-package" value="se.frostyelk.cordova.parse.plugin.ParsePlugin"/>
+			</feature>
+		</config-file>
+		<config-file target="AndroidManifest.xml" parent="/manifest/application">
+			<service android:name="com.parse.PushService"/>
+			<receiver android:name="se.frostyelk.cordova.parse.plugin.ParseWakeUpReceiver">
+				<intent-filter>
+					<action android:name="com.google.android.c2dm.intent.RECEIVE"/>
+					<action android:name="android.intent.action.USER_PRESENT"/>
+					<category android:name="$PACKAGE_NAME"/>
+				</intent-filter>
+			</receiver>
+			<receiver android:name="com.parse.ParseBroadcastReceiver">
+				<intent-filter>
+					<action android:name="android.intent.action.BOOT_COMPLETED"/>
+					<action android:name="android.intent.action.USER_PRESENT"/>
+				</intent-filter>
+			</receiver>
+			<receiver android:name="com.parse.GcmBroadcastReceiver" android:permission="com.google.android.c2dm.permission.SEND">
+				<intent-filter>
+					<action android:name="com.google.android.c2dm.intent.RECEIVE"/>
+					<action android:name="com.google.android.c2dm.intent.REGISTRATION"/>
+					<category android:name="$PACKAGE_NAME"/>
+				</intent-filter>
+			</receiver>
+			<receiver android:exported="false" android:name="se.frostyelk.cordova.parse.plugin.ParsePluginBroadcastReciever">
+				<intent-filter>
+					<action android:name="com.parse.push.intent.RECEIVE"/>
+					<action android:name="com.parse.push.intent.OPEN"/>
+					<action android:name="com.parse.push.intent.DELETE"/>
+				</intent-filter>
+			</receiver>
+		</config-file>
+		<config-file target="AndroidManifest.xml" parent="/manifest">
+			<uses-permission android:name="android.permission.INTERNET"/>
+			<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+			<uses-permission android:name="android.permission.WAKE_LOCK"/>
+			<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+			<uses-permission android:name="android.permission.VIBRATE"/>
+			<uses-permission android:name="android.permission.GET_ACCOUNTS"/>
+			<uses-permission android:name="com.google.android.c2dm.permission.RECEIVE"/>
+			<permission android:protectionLevel="signature" android:name="$PACKAGE_NAME.permission.C2D_MESSAGE"/>
+			<uses-permission android:name="$PACKAGE_NAME.permission.C2D_MESSAGE"/>
+		</config-file>
+		<source-file src="libs/android/parse/Parse-1.8.2.jar" target-dir="libs" framework="true"/>
+		<source-file src="libs/android/parse/bolts-android-1.1.4.jar" target-dir="libs" framework="true"/>
+		<source-file src="libs/android/parse/ParseCrashReporting-1.8.2.jar" target-dir="libs" framework="true"/>
+		<source-file src="src/android/ParsePlugin.java" target-dir="src/se/frostyelk/cordova/parse/plugin/"/>
+		<source-file src="src/android/ParsePluginBroadcastReciever.java" target-dir="src/se/frostyelk/cordova/parse/plugin/"/>
+		<source-file src="src/android/ParseWakeUpReceiver.java" target-dir="src/se/frostyelk/cordova/parse/plugin/"/>
+	</platform>
+	<platform name="ios">
+		<config-file target="config.xml" parent="/*">
+			<feature name="ParsePlugin">
+				<param name="ios-package" value="ParsePlugin"/>
+				<param name="deployment-target" value="7.0"/>
+			</feature>
+		</config-file>
+		<header-file src="src/ios/objc/ParsePlugin.h"/>
+		<source-file src="src/ios/objc/ParsePlugin.m"/>
+		<header-file src="src/ios/objc/AppDelegate+ParsePushNotification.h"/>
+		<source-file src="src/ios/objc/AppDelegate+ParsePushNotification.m"/>
+		<framework src="libs/ios/Parse.framework" custom="true"/>
+		<framework src="libs/ios/Bolts.framework" custom="true"/>
+		<framework src="Accounts.framework"/>
+		<framework src="Social.framework"/>
+		<framework src="AudioToolbox.framework"/>
+		<framework src="CFNetwork.framework"/>
+		<framework src="CoreGraphics.framework"/>
+		<framework src="CoreLocation.framework"/>
+		<framework src="MobileCoreServices.framework"/>
+		<framework src="QuartzCore.framework"/>
+		<framework src="Security.framework"/>
+		<framework src="StoreKit.framework"/>
+		<framework src="SystemConfiguration.framework"/>
+		<framework src="libz.dylib"/>
+		<framework src="libsqlite3.dylib"/>
+	</platform>
 </plugin>
+

--- a/src/android/ParsePlugin.java
+++ b/src/android/ParsePlugin.java
@@ -1,4 +1,5 @@
 /**
+ * Copyright (C) 2015 Glowworm Software
  * Copyright (C) 2015 Frosty Elk AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -95,8 +96,8 @@ public class ParsePlugin extends CordovaPlugin {
         final String url = "javascript:cordova.fireDocumentEvent('onParsePushReceived', " + jsonData.toString() + ");";
         Log.i(LOGTAG, "sendPushToWebView: " + url);
 
-        if (webView != null) {
-            webView.post(new Runnable() {
+        if ((webView != null) && (webView.getView() != null)) {
+            webView.getView().post(new Runnable() {
 
                 @Override
                 public void run() {

--- a/src/android/ParsePlugin.java
+++ b/src/android/ParsePlugin.java
@@ -258,22 +258,16 @@ public class ParsePlugin extends CordovaPlugin {
     }
 
     private PluginResult initialize(final CallbackContext callbackContext, final JSONArray args) {
-        cordova.getThreadPool().execute(new Runnable() {
-            public void run() {
-                try {
-                    appId = args.getString(0);
-                    clientKey = args.getString(1);
-                    Parse.initialize(cordova.getActivity(), appId, clientKey);
-                    ParseInstallation.getCurrentInstallation().save();
-                    ParseAnalytics.trackAppOpenedInBackground(cordova.getActivity().getIntent());
-                    callbackContext.success();
-                } catch (JSONException e) {
-                    callbackContext.error("JSONException: " + e.getMessage());
-                } catch (ParseException e) {
-                    callbackContext.error("ParseException: " + e.getMessage());
-                }
-            }
-        });
+		try {
+			appId = args.getString(0);
+			clientKey = args.getString(1);
+			Parse.initialize(cordova.getActivity().getApplicationContext(), appId, clientKey);
+			ParseInstallation.getCurrentInstallation().saveInBackground();
+			ParseAnalytics.trackAppOpenedInBackground(cordova.getActivity().getIntent());
+			callbackContext.success();
+		} catch (JSONException e) {
+			callbackContext.error("JSONException: " + e.getMessage());
+		}
 
         return null;
     }


### PR DESCRIPTION
Good day, Arne,

I decided to use your Parse plugin for my latest Ionic / Cordova project, and there were a few minor updates that needed to be done for it to work for me. Some of the updates stem from the fact that I am using Cordova 4.
1. I updated the Cordova plugin requirement to v4. This is because of some changes in CordovaWebView that I needed to make, which break backwards compatibility on older versions of Cordova
2. the Cordova Google Play plugin has been changed, and the old one no longer works with Cordova 4
3. the ParsePlugin initialisation call was not returning on my devices until I moved the call onto the UI thread. It now initialises correctly
4. your plugin was not intercepting BOOT_COMPLETE in order to initialise Parse. I have added that intent filter to your ParseWakeUpReceiver

I don't know if you are still planning to keep this repo up to date, but thought that these updates might be helpful. Of the 2 Parse Cordova plugin architectures available, I find yours much easier to work with, which is why I have chosen to continue forward development on this one.

Kind regards,
Richard Le Mesurier
Glowworm Software
Cape Town, SA
